### PR TITLE
fix(units): ensure GEM file is generated in meters

### DIFF
--- a/honeybee_ies/writer.py
+++ b/honeybee_ies/writer.py
@@ -129,6 +129,9 @@ def model_to_ies(
     Returns:
         Path to exported GEM file.
     """
+    # ensure model is in metrics
+    model.convert_to_units(units='Meters')
+
     header = 'COM GEM data file exported by Pollination Rhino\n' \
         'ANT\n'
     rooms_data = [room_to_ies(room) for room in model.rooms]


### PR DESCRIPTION
Turns out IES always expect the units to be in meters. This change will ensure the GEM files are generated in meters regardless of the units of the HBJSON model.