### PR TITLE
fix(deps): bump honeybee-core dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core==1.48.10
+honeybee-core>=1.49.5


### PR DESCRIPTION
Since most of the changes in the core library should not affect honeybee-ies, I'm setting it up to >=