### PR TITLE
fix(tol): set import tolerance to 0.1 mm

### DIFF
--- a/honeybee_ies/reader.py
+++ b/honeybee_ies/reader.py
@@ -204,7 +204,7 @@ def model_from_ies(gem: str) -> Model:
 
     model = Model(
         clean_string(gem_file.stem), rooms=rooms, units='Meters', orphaned_shades=shades,
-        tolerance=0.01
+        tolerance=0.0001
     )
     model.display_name = gem_file.stem
     return model


### PR DESCRIPTION
This is closer to IES's 0.000001 tolerance and still manageable in Rhino.