### PR TITLE
perf(reader): improve aperture edge check routine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core>=1.55.9
+honeybee-core>=1.56.22


### PR DESCRIPTION
This commit improves the routine for pulling the apertures and doors inside if they are touching the edge of the parent face.

The new approach pulls the vertices inside perpendicular to the edge if they are touching the edge and it offsets them inwards if they are touching a corner.
