### PR TITLE
Improve holes translation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,13 @@
-coverage==5.5
-coveralls==2.2.0
 pytest==6.2.4
 pytest-cov==2.12.0
 Sphinx==3.3.1
-docutils==0.17
 sphinx-bootstrap-theme==0.8.1
-sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.2.4
+sphinxcontrib-fulltoc==1.2.0
 sphinx-click==2.7.1
 twine==3.4.1
 wheel==0.36.2
 setuptools==57.0.0
 importlib-metadata==4.3.1
+jinja2==3.0.3
+markupsafe==2.0.1

--- a/honeybee_ies/reader.py
+++ b/honeybee_ies/reader.py
@@ -209,7 +209,8 @@ def _parse_gem_segment(segment: str):
                     holes_3d_snapped, tolerance=MODEL_TOLERANCE * 5, angle_tolerance=0.01
                 )
                 base_faces_holes = [[] for _ in base_faces]
-                for hole_geo in holes_3d_snapped:
+                holes_tracker = []
+                for hole_count, hole_geo in enumerate(holes_3d_snapped):
                     for count, base_face in enumerate(base_faces):
                         if not base_face.holes:
                             continue
@@ -218,8 +219,11 @@ def _parse_gem_segment(segment: str):
                             if hole_geo.center.distance_to_point(f_hole_geo.center) <= MODEL_TOLERANCE * 5:
                                 # this hole is inside the face
                                 base_faces_holes[count].append(f_hole_geo)
+                                holes_tracker.append(hole_count)
                                 break
                     else:
+                        if hole_count in holes_tracker:
+                            continue
                         # the hole is not inside any of the faces
                         hole_face = Face(
                             str(uuid.uuid4()), geometry=hole_geo, type=AirBoundary()

--- a/honeybee_ies/writer.py
+++ b/honeybee_ies/writer.py
@@ -279,7 +279,7 @@ def room_to_ies(room: Room, shade_thickness: float = 0.01) -> str:
 
 
 def model_to_ies(
-    model: Model, folder: str = '.', name: str = None, shade_thickness: float = 0.01
+    model: Model, folder: str = '.', name: str = None, shade_thickness: float = 0.0
         ) -> pathlib.Path:
     """Export a honeybee model to an IES GEM file.
 
@@ -291,7 +291,7 @@ def model_to_ies(
         shade_thickness:The thickness of the shade face in meters. This value will be
             used to extrude shades with no group id. IES doesn't consider the effect of
             shades with no thickness in SunCalc. This function extrudes the geometry to
-            create a closed volume for the shade. Default: 0.01
+            create a closed volume for the shade. Default: 0.0
 
     Returns:
         Path to exported GEM file.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core>=1.56.22
+honeybee-core>=1.56.24


### PR DESCRIPTION
Prior to this commit we used to export holes as a child object regardless of the size of the hole. This could create issues for cases that the entire face was created from holes. This commit introduces additional checks:

If the area of the holes is >= 98% of the parent areas the entire face is exported as AirBoundary face(s).
If the hole edges touch the edges of the parent face, they will be exported as a separate AirBoundary face and will be subtracted from the parent face.
If the hole is fully inside the parent face it will be exported as an additional AirBoundary face and will be added as a hole inside the parent face.