### PR TITLE
fix(reader): set tolerance to a mm

### DIFF
--- a/honeybee_ies/reader.py
+++ b/honeybee_ies/reader.py
@@ -287,7 +287,7 @@ def model_from_ies(gem: str) -> Model:
 
     model = Model(
         clean_string(gem_file.stem), rooms=rooms, units='Meters', orphaned_shades=shades,
-        tolerance=0.0001
+        tolerance=MODEL_TOLERANCE
     )
     model.display_name = gem_file.stem
     return model


### PR DESCRIPTION
After dealing with geometry issues in loading the models in Rhino we decided to set the tolerance back to a mm that should fit most of the models that we have received from the users.