### PR TITLE
fix(reader): fix duplicate ids for trees

### DIFF
--- a/honeybee_ies/reader.py
+++ b/honeybee_ies/reader.py
@@ -66,7 +66,7 @@ def _update_name(obj: Union[Shade, Room], display_name: str, count: int = None):
 
     id_ = _get_id(display_name)
     if id_:
-        obj.identifier = id_ if count else f'{id_}'
+        obj.identifier = f'{id_}-{count}' if count else id_
         obj.display_name = display_name.replace(f' [{id_}]', '')
     else:
         obj.display_name = display_name


### PR DESCRIPTION
Add a count for the second rectangle. This rectangle will be ignored when it is imported back to GEM, and the ID of it doesn't really matter.
