### PR TITLE
fix(serialize): Add options to translate to/from GEM file contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ tox.ini
 .eggs
 *.code-workspace
 .env
+build
 
 /tests/assets/temp

--- a/honeybee_ies/reader.py
+++ b/honeybee_ies/reader.py
@@ -469,11 +469,17 @@ def _parse_gem_segment(
         return faces
 
 
-def model_from_gem(gem_str: str, model_id: str='Unnamed', model_name=None) -> Model:
+def model_from_gem(
+        gem_str: str, model_id: str = 'Unnamed', model_name: str = None
+    ) -> Model:
     """Create a Honeybee Model from the string contents of a VE GEM file.
 
     Args:
         gem_str: Text string representation of the contents of a GEM file.
+        model_id: Text string to be applied as the Model identifier. Typically,
+            this is derived from the GEM file name. (Default: Unnamed).
+        model_name: Text string to be applied as the Model identifier. If None,
+            this will be the same as the model_id. (Default: None).
 
     Returns:
         A Honeybee Model derived from the GEM file contents.
@@ -503,7 +509,14 @@ def model_from_gem(gem_str: str, model_id: str='Unnamed', model_name=None) -> Mo
 
 
 def model_from_ies(gem: str) -> Model:
-    """Create a Honeybee Model from a VE GEM file."""
+    """Create a Honeybee Model from a VE GEM file.
+
+    Args:
+        gem: String for the path to a VE GEM file.
+
+    Returns:
+        A Honeybee Model derived from the GEM file contents.
+    """
     # load the contents of the GEM file
     gem_file = pathlib.Path(gem)
     file_contents = gem_file.read_text()


### PR DESCRIPTION
Hey @mostaphaRoudsari ,

I know that we already talked about this in relation to the model editor. This PR is essentially just adding a method to translate Honeybee Models to/from GEM file contents instead of always requiring file paths and a file system.

The reason why I did this now is because I'm putting together a generalized import_file script for the Model Editor and, with the changes in this PR, I'll be able to write it in a way that works for importing both HBJSON and GEM to the Model Editor (since they'll both be translate-able to DFJSON).

I think this will be a better proof of concept than an importer that only works with HBJSON and it shows that the Model Editor could have legs beyond just the Revit and Rhino plugins (eg. as a standalone editor for IES GEM files).