### PR TITLE
fix(writer): catch MemoryError for rooms with many holes

### DIFF
--- a/honeybee_ies/writer.py
+++ b/honeybee_ies/writer.py
@@ -374,6 +374,17 @@ def room_to_ies(room: Room, shade_thickness: float = 0.01) -> str:
                 )
                 fgs = [face.geometry]
                 indexes = [[str(v + 1) for v in face_i[0]]]
+            except MemoryError:
+                # ignore the holes
+                print(
+                    f'Failed to resolve the holes for {room.display_name} likely '
+                    'because there are too many of them in a single room. Check the '
+                    'input model and try to decrease the number of holes by splitting '
+                    'the room. If the holes are because of column holes, try to merge '
+                    'them into the room itself.'
+                )
+                fgs = [face.geometry]
+                indexes = [[str(v + 1) for v in face_i[0]]]
             else:
                 face_count += len(fgs) - 1
                 indexes = [


### PR DESCRIPTION
In some cases the user exports a model from Revit without removing the column holes. Or they export self-intersecting rooms with column holes. These cases can cause `MemoryError` exception in `ladybug-geometry`. This check ensures those cases won't stop the model from being exported, and instead provides a helpful message about the problematic room.

Here is a sample traceback:

```
Traceback (most recent call last):
  File "/lib/python312.zip/_pyodide/_base.py", line 597, in eval_code_async
    await CodeRunner(
  File "/lib/python312.zip/_pyodide/_base.py", line 411, in run_async
    coroutine = eval(self.code, globals, locals)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<exec>", line 26, in <module>
  File "/home/pyodide/dragonfly_iesve/writer.py", line 27, in model_to_gem
    return hb_model_to_gem(hb_model)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pyodide/honeybee_ies/writer.py", line 484, in model_to_gem
    rooms_data = [room_to_ies(room, shade_thickness=shade_thickness)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pyodide/honeybee_ies/writer.py", line 366, in room_to_ies
    fgs = face.geometry.split_through_holes()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pyodide/ladybug_geometry/geometry3d/face.py", line 1241, in split_through_holes
    faces_to_test.append(f)
MemoryError
```
